### PR TITLE
feat: create mountpoint for named volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,6 @@ RUN rm -rf /tmp/dashcore*
 ADD ./bin /usr/local/bin
 RUN chmod a+x /usr/local/bin/*
 
-# For some reason, docker.io (0.9.1~dfsg1-2) pkg in Ubuntu 14.04 has permission
-# denied issues when executing /bin/bash from trusted builds.  Building locally
-# works fine (strange).  Using the upstream docker (0.11.1) pkg from
-# http://get.docker.io/ubuntu works fine also and seems simpler.
 USER dash
 
 VOLUME ["/dash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV USER_ID ${USER_ID:-1000}
 ENV GROUP_ID ${GROUP_ID:-1000}
 RUN groupadd -g ${GROUP_ID} dash
 RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
-
+RUN mkdir /dash/.dashcore
 RUN chown dash:dash -R /dash
 
 ADD https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-x86_64-linux-gnu.tar.gz /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:bionic-1.0.0
-MAINTAINER Holger Schinzel <holger@dash.org>
+LABEL maintainer="holger@dash.org,leon.white@dash.org"
 
 ARG USER_ID
 ARG GROUP_ID

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Holger Schinzel <holger@dash.org>
 
 ARG USER_ID


### PR DESCRIPTION
This PR creates a mountpoint in the default location expected by dashd (`~/.dashcore/`), simplifying container management in [mn-bootstrap](https://github.com/dashevo/mn-bootstrap). It is backwards compatible since consumers of the image can still bind-mount the datadir wherever they want and pass the datadir argument at startup, as was done in the past. It also updates the baseimage, since phusion has changed their tagging system, which was causing builds to fail. This bumps the container OS to from Ubuntu 16.04 LTS to 18.04 LTS, which seemed to have no negative effects during testing (but should maybe also merge the outstanding and possibly related PRs from nmarley).