### PR TITLE
feat: Add multi-arch build support and push to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: bash
 dist: focal
 sudo: required
 
+addons:
+  apt:
+    update: true
+    sources:
+      - sourceline: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
+
 env:
   global:
     - TAG=0.16.0.0-rc3
@@ -9,6 +15,7 @@ env:
 before_install:
   - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
   - docker version
   - docker info
   - docker buildx version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ dist: focal
 sudo: required
 services: docker
 
+addons:
+  apt:
+    update: true
+    packages:
+      - docker.io
+
 env:
   global:
     - TAG=0.16.0.0-rc3
@@ -10,7 +16,11 @@ env:
 
 before_install:
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - sudo systemctl restart docker
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - apt-cache madison docker-ce
+  #- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.8~3-0~ubuntu-bionic # pin version for reproducibility
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: bash
 dist: focal
 sudo: required
+services: docker
 
 env:
-  - TAG=0.16.0.0-rc3
+  global:
+    - TAG=0.16.0.0-rc3
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+
+before_install:
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - sudo service docker start
 
 install:
-  - curl -fsSL https://get.docker.com | sh
-  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - mkdir -p $HOME/.docker
-  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
-  - sudo service docker start
   - git clone https://github.com/docker-library/official-images.git official-images
 
 before_script:
-  - env | sort
   - image="strophy/dashd:$TAG"
   - docker version
   - docker buildx version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
   - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
-  - docker version
-  - docker info
-  - docker buildx version
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images
@@ -27,7 +24,7 @@ before_script:
   - image="strophy/dashd:$TAG"
 
 script:
-  - docker build -t "$image" .
+  - docker buildx build --platform linux/amd64,linux/arm64 -t "$image" .
   - official-images/test/run.sh "$image"
   - test/run.sh "$image"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 before_install:
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-  - sudo service docker start
+  - sudo systemctl restart docker
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: bash
 dist: focal
-services: docker
+sudo: required
 
 env:
-  - TAG=0.16.0.0-rc3 DOCKER_CLI_EXPERIMENTAL=enabled
+  - TAG=0.16.0.0-rc3
 
 install:
+  - curl -fsSL https://get.docker.com | sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
   - git clone https://github.com/docker-library/official-images.git official-images
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
   - |
-    if [ $BUILD == "release" ]; then
+    if [ $BUILD == "dashd" ]; then
       export TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
     else
       export TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: bash
 dist: focal
 sudo: required
 
-addons:
-  apt:
-    update: true
-    packages:
-      - docker.io
-
 env:
   global:
     - TAG=0.16.0.0-rc3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,17 @@ addons:
 env:
   global:
     - TAG=0.16.0.0-rc3
+    - DOCKER_CLI_EXPERIMENTAL=enabled
 
 before_install:
-  - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
 
 install:
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
   - git clone https://github.com/docker-library/official-images.git official-images
+
+after_install:
+  - docker buildx create --name xbuilder --use
 
 before_script:
   - image="strophy/dashd:$TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
   - |
     if [ $BUILD == "dashd" ]; then
-      export TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
+      export TAG=$(curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-)
     else
-      export TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-
+      export TAG=$(curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-)
     fi
   - echo $TAG
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ env:
     - TAG=0.16.0.0-rc3
     - DOCKER_CLI_EXPERIMENTAL=enabled
 
+before_install:
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+
 install:
-  - sudo apt-get -y install docker-ce binfmt-support
+  - sudo apt-get -y install docker-ce
   - git clone https://github.com/docker-library/official-images.git official-images
   - docker buildx create --name xbuilder --use
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,20 @@ env:
     - TAG=0.16.0.0-rc3
 
 before_install:
+  - cat /etc/docker/daemon.json
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
   - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - apt-cache madison docker-ce
-  - sudo apt-get -y install docker-ce=5:19.03.12~3-0~ubuntu-focal
+  - sudo systemctl restart docker
+  - docker version
+  - docker info
+  - docker buildx version
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images
 
 before_script:
   - image="strophy/dashd:$TAG"
-  - docker version
-  - docker info
-  - docker buildx version
 
 script:
   - docker build -t "$image" .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 
 before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-  - if [ $BUILD == "release" ] then
+  - |
+    if [ $BUILD == "release" ]; then
       export TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
     else
       export TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_script:
 
 script:
   - docker buildx build --push --build-arg VERSION="$TAG" --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$image" .
-  - official-images/test/run.sh "$image"
-  - test/run.sh "$image"
+  #- official-images/test/run.sh "$image"
+  #- test/run.sh "$image"
 
 after_script:
   - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ addons:
 
 env:
   global:
-    - TAG=0.16.0.0-rc3
     - DOCKER_CLI_EXPERIMENTAL=enabled
+  jobs:
+    - TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-
+    - TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
 
 before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: bash
 dist: focal
 sudo: required
-services: docker
 
 addons:
   apt:
@@ -20,7 +19,7 @@ before_install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - apt-cache madison docker-ce
-  #- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.8~3-0~ubuntu-bionic # pin version for reproducibility
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=55:19.03.12~3-0~ubuntu-focal
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,17 @@ env:
     - BUILD=dashd-develop
 
 before_install:
-  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - sudo apt-get -y install docker-ce
   - |
     if [ $BUILD == "dashd" ]; then
       export TAG=$(curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-)
     else
       export TAG=$(curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-)
     fi
-  - echo $TAG
 
 install:
-  - sudo apt-get -y install docker-ce
-  - git clone https://github.com/docker-library/official-images.git official-images
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  #- git clone https://github.com/docker-library/official-images.git official-images
   - docker buildx create --name xbuilder --use
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
 script:
-  - docker buildx build --push --build-arg VERSION="$TAG" --platform linux/amd64,linux/arm64 -t "$image" .
+  - docker buildx build --push --build-arg VERSION="$TAG" --platform linux/amd64,linux/arm64,linux/arm/v7 -t "$image" .
   - official-images/test/run.sh "$image"
   - test/run.sh "$image"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - apt-cache madison docker-ce
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=55:19.03.12~3-0~ubuntu-focal
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - apt-cache madison docker-ce
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
+  - sudo apt-get -y install docker-ce=5:19.03.12~3-0~ubuntu-focal
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,16 @@ before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
 
 install:
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
+  - sudo apt-get -y install docker-ce=5:19.03.12~3-0~ubuntu-focal
   - git clone https://github.com/docker-library/official-images.git official-images
   - docker buildx create --name xbuilder --use
 
 before_script:
   - image="strophy/dashd:$TAG"
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
 script:
-  - docker buildx build --platform linux/amd64,linux/arm64 -t "$image" .
+  - docker buildx build --push --platform linux/amd64,linux/arm64 -t "$image" .
   - official-images/test/run.sh "$image"
   - test/run.sh "$image"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,17 @@ env:
   global:
     - DOCKER_CLI_EXPERIMENTAL=enabled
   jobs:
-    - TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-
-    - TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
+    - BUILD=dashd
+    - BUILD=dashd-develop
 
 before_install:
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - if [ $BUILD == "release" ] then
+      export TAG=curl https://api.github.com/repos/dashpay/dash/releases/latest -s | jq .tag_name -r | cut -c2-
+    else
+      export TAG=curl https://api.github.com/repos/dashpay/dash/tags -s | jq .[0].name -r | cut -c2-
+    fi
+  - echo $TAG
 
 install:
   - sudo apt-get -y install docker-ce
@@ -24,7 +30,7 @@ install:
   - docker buildx create --name xbuilder --use
 
 before_script:
-  - image="strophy/dashd:$TAG"
+  - image="strophy/$BUILD:$TAG"
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: bash
+dist: focal
 services: docker
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 before_script:
   - image="strophy/dashd:$TAG"
   - docker version
+  - docker info
   - docker buildx version
 
 script:
@@ -27,5 +28,9 @@ script:
 
 after_script:
   - docker images
+
+after_failure:
+  - sudo systemctl status docker.service
+  - sudo journalctl -xe
 
 # vim:set et ts=2 sw=2:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ dist: focal
 services: docker
 
 env:
-  - VARIANT=trusty
+  - TAG=0.16.0.0-rc3
+  - DOCKER_CLI_EXPERIMENTAL=enabled
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images
 
 before_script:
   - env | sort
-  - image="dashd:$VARIANT"
+  - image="strophy/dashd:$TAG"
+  - docker buildx version
 
 script:
   - docker build -t "$image" .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
     - TAG=0.16.0.0-rc3
 
 before_install:
-  - cat /etc/docker/daemon.json
-  - cat ~/.docker/config.json
   - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
   - docker version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: focal
 services: docker
 
 env:
-  - TAG=0.16.0.0-rc3
-  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - TAG=0.16.0.0-rc3 DOCKER_CLI_EXPERIMENTAL=enabled
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images
@@ -12,6 +11,7 @@ install:
 before_script:
   - env | sort
   - image="strophy/dashd:$TAG"
+  - docker version
   - docker buildx version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ before_install:
 install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.12~3-0~ubuntu-focal
   - git clone https://github.com/docker-library/official-images.git official-images
-
-after_install:
   - docker buildx create --name xbuilder --use
 
 before_script:
@@ -33,9 +31,5 @@ script:
 
 after_script:
   - docker images
-
-after_failure:
-  - sudo systemctl status docker.service
-  - sudo journalctl -xe
 
 # vim:set et ts=2 sw=2:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ sudo: required
 env:
   global:
     - TAG=0.16.0.0-rc3
-    - DOCKER_CLI_EXPERIMENTAL=enabled
 
 before_install:
   - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - export DOCKER_CLI_EXPERIMENTAL=enabled
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ env:
     - TAG=0.16.0.0-rc3
     - DOCKER_CLI_EXPERIMENTAL=enabled
 
-before_install:
-  - docker run --rm --privileged docker/binfmt
-
 install:
-  - sudo apt-get -y install docker-ce
+  - sudo apt-get -y install docker-ce binfmt-support
   - git clone https://github.com/docker-library/official-images.git official-images
   - docker buildx create --name xbuilder --use
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
 
 before_install:
-  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker run --rm --privileged docker/binfmt
 
 install:
-  - sudo apt-get -y install docker-ce=5:19.03.12~3-0~ubuntu-focal
+  - sudo apt-get -y install docker-ce
   - git clone https://github.com/docker-library/official-images.git official-images
   - docker buildx create --name xbuilder --use
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ env:
 
 before_install:
   - cat /etc/docker/daemon.json
-  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - cat ~/.docker/config.json
   - export DOCKER_CLI_EXPERIMENTAL=enabled
   - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-  - sudo systemctl restart docker
   - docker version
   - docker info
   - docker buildx version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
 script:
-  - docker buildx build --push --platform linux/amd64,linux/arm64 -t "$image" .
+  - docker buildx build --push --build-arg VERSION="$TAG" --platform linux/amd64,linux/arm64 -t "$image" .
   - official-images/test/run.sh "$image"
   - test/run.sh "$image"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
 RUN mkdir /dash/.dashcore
 RUN chown dash:dash -R /dash
 
-ADD https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-x86_64-linux-gnu.tar.gz /tmp/
+RUN apt-get update
+RUN /sbin/install_clean -y wget
+
+RUN wget https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-$(uname -m)-linux-gnu.tar.gz -P /tmp
 RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
 RUN cp /tmp/dashcore*/bin/*  /usr/local/bin
 RUN rm -rf /tmp/dashcore*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update
 RUN /sbin/install_clean -y wget
 
 RUN mach=$(uname -m)
+RUN echo $mach
 RUN case $mach in armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac
+RUN echo $arch 
 RUN wget https://github.com/dashpay/dash/releases/download/${VERSION}/dashcore-${VERSION}-$arch.tar.gz -P /tmp
 RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
 RUN cp /tmp/dashcore*/bin/*  /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN chown dash:dash -R /dash
 RUN apt-get update
 RUN /sbin/install_clean -y wget
 
-RUN case $(uname -m) in  armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type ($(uname -m)) not supported."; ;; esac
+RUN mach=$(uname -m)
+RUN case $mach in armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac
 RUN wget https://github.com/dashpay/dash/releases/download/${VERSION}/dashcore-${VERSION}-$arch.tar.gz -P /tmp
 RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
 RUN cp /tmp/dashcore*/bin/*  /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="holger@dash.org,leon.white@dash.org"
 
 ARG USER_ID
 ARG GROUP_ID
-ARG VERSION
+ARG VERSION=0.15.0.0
 
 ENV HOME /dash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,12 @@ RUN chown dash:dash -R /dash
 RUN apt-get update
 RUN /sbin/install_clean -y wget
 
-RUN mach=$(uname -m)
-RUN echo $mach
-RUN case $mach in armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac
-RUN echo $arch 
-RUN wget https://github.com/dashpay/dash/releases/download/${VERSION}/dashcore-${VERSION}-$arch.tar.gz -P /tmp
-RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
-RUN cp /tmp/dashcore*/bin/*  /usr/local/bin
-RUN rm -rf /tmp/dashcore*
+RUN mach=$(uname -m) \
+      && case $mach in armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac \
+      && wget https://github.com/dashpay/dash/releases/download/v${VERSION}/dashcore-${VERSION}-$arch.tar.gz -P /tmp
+RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/ \
+      && cp /tmp/dashcore*/bin/*  /usr/local/bin \
+      && rm -rf /tmp/dashcore*
 
 ADD ./bin /usr/local/bin
 RUN chmod a+x /usr/local/bin/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN chown dash:dash -R /dash
 RUN apt-get update
 RUN /sbin/install_clean -y wget
 
-RUN wget https://github.com/dashpay/dash/releases/download/v0.15.0.0/dashcore-0.15.0.0-$(uname -m)-linux-gnu.tar.gz -P /tmp
+RUN wget https://github.com/dashpay/dash/releases/download/v0.16.0.0-rc3/dashcore-0.16.0.0-rc3-$(uname -m)-linux-gnu.tar.gz -P /tmp
 RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
 RUN cp /tmp/dashcore*/bin/*  /usr/local/bin
 RUN rm -rf /tmp/dashcore*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="holger@dash.org,leon.white@dash.org"
 
 ARG USER_ID
 ARG GROUP_ID
+ARG VERSION
 
 ENV HOME /dash
 
@@ -17,7 +18,8 @@ RUN chown dash:dash -R /dash
 RUN apt-get update
 RUN /sbin/install_clean -y wget
 
-RUN wget https://github.com/dashpay/dash/releases/download/v0.16.0.0-rc3/dashcore-0.16.0.0-rc3-$(uname -m)-linux-gnu.tar.gz -P /tmp
+RUN case $(uname -m) in  armv7l) arch="arm-linux-gnueabihf"; ;; aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type ($(uname -m)) not supported."; ;; esac
+RUN wget https://github.com/dashpay/dash/releases/download/${VERSION}/dashcore-${VERSION}-$arch.tar.gz -P /tmp
 RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
 RUN cp /tmp/dashcore*/bin/*  /usr/local/bin
 RUN rm -rf /tmp/dashcore*


### PR DESCRIPTION
This PR modifies the Dockerfile and Travis CI to build images for amd64, arm64 and armv7l and push to Docker Hub. This should make it possible to run mn-bootstrap on any of these platforms and automatically pull the correct arch.